### PR TITLE
Implement OAuth2 redirect URI capture and update authentication succe…

### DIFF
--- a/src/main/java/org/zemo/omninet/security/config/OAuth2RedirectCaptureFilter.java
+++ b/src/main/java/org/zemo/omninet/security/config/OAuth2RedirectCaptureFilter.java
@@ -1,0 +1,28 @@
+package org.zemo.omninet.security.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class OAuth2RedirectCaptureFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        if (request.getRequestURI().startsWith("/oauth2/authorization/")) {
+            String redirectUri = request.getParameter("redirect_uri");
+            if (redirectUri != null && !redirectUri.isBlank()) {
+                request.getSession().setAttribute("OAUTH2_REDIRECT_URI", redirectUri);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/org/zemo/omninet/security/config/SecurityConfig.java
+++ b/src/main/java/org/zemo/omninet/security/config/SecurityConfig.java
@@ -9,6 +9,7 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -26,15 +27,18 @@ public class SecurityConfig {
     private final CustomAuthenticationSuccessHandler customAuthenticationSuccessHandler;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final OAuth2RedirectCaptureFilter oAuth2RedirectCaptureFilter;
 
     public SecurityConfig(CustomOAuth2UserService customOAuth2UserService,
                           CustomAuthenticationSuccessHandler customAuthenticationSuccessHandler,
                           JwtAuthenticationFilter jwtAuthenticationFilter,
-                          JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint) {
+                          JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint,
+                          OAuth2RedirectCaptureFilter oAuth2RedirectCaptureFilter) {
         this.customOAuth2UserService = customOAuth2UserService;
         this.customAuthenticationSuccessHandler = customAuthenticationSuccessHandler;
         this.jwtAuthenticationFilter = jwtAuthenticationFilter;
         this.jwtAuthenticationEntryPoint = jwtAuthenticationEntryPoint;
+        this.oAuth2RedirectCaptureFilter = oAuth2RedirectCaptureFilter;
     }
 
     @Bean
@@ -74,10 +78,10 @@ public class SecurityConfig {
                         .requestMatchers("/api/**").authenticated()
                         .anyRequest().authenticated()
                 )
+                .addFilterBefore(oAuth2RedirectCaptureFilter, OAuth2AuthorizationRequestRedirectFilter.class)
                 .oauth2Login(oauth2 -> oauth2
                         .loginPage("/login")
                         .successHandler(customAuthenticationSuccessHandler)
-                        .failureUrl("/login?error=true")
                         .userInfoEndpoint(userInfo -> userInfo
                                 .userService(customOAuth2UserService)
                         )


### PR DESCRIPTION
This pull request introduces support for dynamic OAuth2 redirect URIs, allowing the application to redirect users to a custom URI after successful authentication. The main changes involve capturing a `redirect_uri` parameter during the OAuth2 authorization request, storing it in the session, and then using it (if present) after authentication. If no custom redirect URI is provided, the system falls back to a default value.

**OAuth2 Redirect URI Capture and Usage:**

* Added a new filter `OAuth2RedirectCaptureFilter` to intercept OAuth2 authorization requests, capture the `redirect_uri` parameter, and store it in the session.
* Updated `CustomAuthenticationSuccessHandler` to retrieve the `OAUTH2_REDIRECT_URI` from the session after successful authentication, use it for redirection, and remove it from the session. Falls back to a default URI if none is set.
* Registered the new filter in `SecurityConfig` to run before the OAuth2 authorization redirect filter, and updated the configuration and constructor accordingly. [[1]](diffhunk://#diff-448194485869a369111d751c74bb73a3d64732d4ca98c976b96edd7e44f748ceR12) [[2]](diffhunk://#diff-448194485869a369111d751c74bb73a3d64732d4ca98c976b96edd7e44f748ceR30-R41) [[3]](diffhunk://#diff-448194485869a369111d751c74bb73a3d64732d4ca98c976b96edd7e44f748ceR81-L80)

**Minor Improvements:**

* Cleaned up exception handling in `CustomAuthenticationSuccessHandler` by removing an unnecessary exception type.
* Added necessary imports for session management in `CustomAuthenticationSuccessHandler`.